### PR TITLE
Cast field_id as string

### DIFF
--- a/models/stg_jira__field.sql
+++ b/models/stg_jira__field.sql
@@ -22,7 +22,7 @@ fields as (
 final as (
     
     select 
-        id as field_id,
+        cast(id as {{ dbt_utils.type_string() }}) as field_id,
         is_array,
         is_custom,
         name as field_name,

--- a/models/stg_jira__issue_field_history.sql
+++ b/models/stg_jira__issue_field_history.sql
@@ -22,7 +22,7 @@ fields as (
 final as (
     
     select 
-        field_id,
+        cast(field_id as {{ dbt_utils.type_string() }}) as field_id,
         issue_id,
         {% if target.type == 'bigquery' %}
         time as updated_at,

--- a/models/stg_jira__issue_multiselect_history.sql
+++ b/models/stg_jira__issue_multiselect_history.sql
@@ -23,7 +23,7 @@ final as (
     
     select 
         _fivetran_id,
-        field_id,
+        cast(field_id as {{ dbt_utils.type_string() }}) as field_id,
         issue_id,
         {% if target.type == 'bigquery' %}
         time as updated_at,


### PR DESCRIPTION
As discussed, this is to cast the field_id as a string early, so that all of the downstream models have the same field_id data type.  Field_ids are alphanumeric, so should not be integers.