### PR TITLE
Add logic to allow users to disable the "components" table

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,7 @@ jobs:
             dbt deps
             dbt seed --target redshift --full-refresh
             dbt run --target redshift --full-refresh
+            dbt run --vars '{jira_using_sprints: false, jira_using_components: false}' --target redshift --full-refresh
             dbt test --target redshift
       - run:
           name: "Run Tests - Snowflake"
@@ -43,6 +44,7 @@ jobs:
             dbt deps
             dbt seed --target snowflake --full-refresh
             dbt run --target snowflake --full-refresh
+            dbt run --vars '{jira_using_sprints: false, jira_using_components: false}' --target snowflake --full-refresh
             dbt test --target snowflake
       - run:
           name: "Run Tests - BigQuery"
@@ -56,6 +58,7 @@ jobs:
             dbt deps
             dbt seed --target bigquery --full-refresh
             dbt run --target bigquery --full-refresh
+            dbt run --vars '{jira_using_sprints: false, jira_using_components: false}' --target bigquery --full-refresh
             dbt test --target bigquery
       - save_cache:
           key: deps2-{{ .Branch }}

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ config-version: 2
 vars:
   jira_source:
     jira_using_sprints: false   # Disable if you do not have the sprint table, or if you do not want sprint related metrics reported
+    jira_using_components: false # Disable if you do not have the component table, or if you do not want component related metrics reported
 ```
 
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -21,6 +21,7 @@ vars:
     field: "{{ source('jira', 'field') }}"
     sprint: "{{ source('jira', 'sprint') }}"
     jira_using_sprints: true # disable if you are not using sprints in Jira
+    jira_using_components: true # disable if you are not using components in Jira
 
 
 models:

--- a/models/stg_jira__component.sql
+++ b/models/stg_jira__component.sql
@@ -1,3 +1,4 @@
+{{ config(enabled=var('jira_using_components', True)) }}
 
 with base as (
 

--- a/models/tmp/stg_jira__component_tmp.sql
+++ b/models/tmp/stg_jira__component_tmp.sql
@@ -1,1 +1,3 @@
+{{ config(enabled=var('jira_using_components', True)) }}
+
 select * from {{ var('component') }}


### PR DESCRIPTION
This PR introduces the `jira_using_components` variable, which can be set to false to allow users to disable any models related to jira's component table. 

[Related issue ](https://github.com/fivetran/dbt_jira_source/issues/7)