### PR TITLE
Add parent_id field in the field_option table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# dbt_jira_source v0.4.2
+## Changes
+Add parent_id field in the field_option table. The field is used when defining custom fields as parent and child custom fields can be created to define some main categories and subcategories. 
+
+Changes done according to the issue:https://github.com/fivetran/dbt_jira_source/issues/31
+
 # dbt_jira_source v0.4.1
 ## Features
 - Makes Priority data optional. If `jira_using_priorities: false` in `dbt_project.yml`, then `stg_jira__priority_tmp` and `stg_jira__priority` won't build. ([#30](https://github.com/fivetran/dbt_jira_source/pull/30))

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'jira_source'
-version: '0.4.1'
+version: '0.4.2'
 config-version: 2
 require-dbt-version: [">=1.0.0", "<2.0.0"]
 

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'jira_source_integration_tests'
-version: '0.4.1'
+version: '0.4.2'
 config-version: 2
 profile: 'integration_tests'
 

--- a/models/src_jira.yml
+++ b/models/src_jira.yml
@@ -69,6 +69,8 @@ sources:
         columns:
           - name: id
             description: The ID of the custom field.
+          - name: parent_id
+            description: The ID of the parent custom field.
           - name: name
             description: Name of the field option.
 

--- a/models/stg_jira.yml
+++ b/models/stg_jira.yml
@@ -65,6 +65,8 @@ models:
         description: The ID of the custom field.
         tests:
           - not_null
+      - name: parent_field_id
+        description: The ID of the parent custom field.
       - name: field_option_name
         description: Name of the field option.
 

--- a/models/stg_jira__field_option.sql
+++ b/models/stg_jira__field_option.sql
@@ -23,6 +23,7 @@ final as (
     
     select 
         id as field_id,
+        parent_id as parent_field_id,
         name as field_option_name
 
     from fields


### PR DESCRIPTION
Pull Request
**Are you a current Fivetran customer?** 
Sergi Solà - Data Analytics Engineer - Wallbox Chargers

**What change(s) does this PR introduce?** 
<!--- Describe what changes your PR introduces to the package and how to leverage this new feature. -->
Add parent_id field in the field_option table. The field is used when defining custom fields as parent and child custom fields can be created to define some main categories and subcategories.

**Did you update the CHANGELOG?** 
<!--- Please update the new package version’s CHANGELOG entry detailing the changes included in this PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] Yes

**Does this PR introduce a breaking change?**
<!--- Does this PR introduce changes that will cause current package users' jobs to fail or require a `--full-refresh`? -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] Yes (please provide breaking change details below.)
- [x] No  (please provide an explanation as to how the change is non-breaking below.)

It does not introduce a breaking change in the package as we are only introducing one new field in a table, from which no other table depends in the package.

**Did you update the dbt_project.yml files with the version upgrade (please leverage standard semantic versioning)? (In both your main project and integration_tests)** 
<!--- The dbt_project.yml and the integration_tests/dbt_project.yml files contain the version number. Be sure to upgrade it accordingly -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] Yes

**Is this PR in response to a previously created Bug or Feature Request**
<!--- If an Issue was created it is helpful to track the progress by linking it in the PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] Yes, Issue/Feature [link bug/feature number here] --> https://github.com/fivetran/dbt_jira_source/issues/31
- [ ] No 

**How did you test the PR changes?** 
<!--- Proof of testing is required in order for the PR to be approved. -->
<!--- To check a box, remove the space and insert an x in the box (eg. [x] CircleCi). --> 
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] CircleCi <!--- CircleCi testing is only applicable to Fivetran employees. --> 
- [x] Local (please provide additional testing details below)

**Select which warehouse(s) were used to test the PR**
<!--- To check a warehouse remove the space and insert an x in the box (eg. [x] Bigquery). --> 
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] BigQuery
- [ ] Redshift
- [x] Snowflake
- [ ] Postgres
- [ ] Databricks
- [ ] Other (provide details below)

**Provide an emoji that best describes your current mood**
<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
:dancer:

**Feedback**

We are so excited you decided to contribute to the Fivetran community dbt package! We continue to work to improve the packages and would greatly appreciate your [feedback](https://www.surveymonkey.com/r/DQ7K7WW) on our existing dbt packages or what you'd like to see next.
